### PR TITLE
Destroy runners when work is done

### DIFF
--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -15,56 +15,84 @@ namespace ComponentTask.Internal
 
         public UnityEngine.Component ComponentToFollow { get; set; }
 
-        public Task StartTask(Func<Task> taskCreator) =>
-            this.taskRunner.StartTask(taskCreator);
+        public bool IsFinished { get; private set; }
 
-        public Task StartTask(Func<CancellationToken, Task> taskCreator) =>
-            this.taskRunner.StartTask(taskCreator);
+        public Task StartTask(Func<Task> taskCreator)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator);
+        }
 
-        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data) =>
-            this.taskRunner.StartTask(taskCreator, data);
+        public Task StartTask(Func<CancellationToken, Task> taskCreator)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator);
+        }
 
-        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data) =>
-            this.taskRunner.StartTask(taskCreator, data);
+        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator, data);
+        }
 
-        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator) =>
-            this.taskRunner.StartTask(taskCreator);
+        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator, data);
+        }
 
-        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator) =>
-            this.taskRunner.StartTask(taskCreator);
+        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator);
+        }
 
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data) =>
-            this.taskRunner.StartTask(taskCreator, data);
+        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator);
+        }
 
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data) =>
-            this.taskRunner.StartTask(taskCreator, data);
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator, data);
+        }
+
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data)
+        {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
+            return this.taskRunner.StartTask(taskCreator, data);
+        }
 
         // Dynamically called from the Unity runtime.
         private void LateUpdate()
         {
+            System.Diagnostics.Debug.Assert(!this.IsFinished, "Already finished runner was updated");
+
             // Check if we have a 'ComponentToFollow' assigned.
             if (this.ComponentToFollow is null)
             {
                 // If not then always just execute the runner.
-                this.taskRunner.Execute();
+                this.Execute();
             }
             else
             {
                 // If the component we are following has been destroyed then we destroy ourselves.
                 if (!this.ComponentToFollow)
-                    UnityEngine.Object.Destroy(this);
+                    this.Destroy();
                 else
                 {
                     // If the component is a 'Behaviour' then we update when its enabled.
                     if (ComponentToFollow is UnityEngine.Behaviour behaviour)
                     {
                         if (behaviour.isActiveAndEnabled)
-                            this.taskRunner.Execute();
+                            this.Execute();
                     }
                     else
                     {
                         // Otherwise we always update.
-                        this.taskRunner.Execute();
+                        this.Execute();
                     }
                 }
             }
@@ -72,6 +100,21 @@ namespace ComponentTask.Internal
 
         // Dynamically called from the Unity runtime.
         private void OnDestroy() => this.taskRunner.Dispose();
+
+        private void Execute()
+        {
+            var workRemaining = this.taskRunner.Execute();
+
+            // If we've finished all the work then destroy ourselves.
+            if (!workRemaining)
+                this.Destroy();
+        }
+
+        private void Destroy()
+        {
+            this.IsFinished = true;
+            UnityEngine.Object.Destroy(this);
+        }
 
         void IExceptionHandler.Handle(Exception exception)
         {

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -169,11 +169,13 @@ namespace ComponentTask
         /// <summary>
         /// Execute all the work that was 'scheduled' by the tasks running on this runner.
         /// </summary>
-        public void Execute()
+        /// <returns>True if still running work, False if all work has finished.</returns>
+        public bool Execute()
         {
             if (this.isDisposed)
                 throw new ObjectDisposedException(nameof(LocalTaskRunner));
 
+            bool tasksRemaining;
             try
             {
                 // Execute all the work that was scheduled on this runner.
@@ -192,8 +194,12 @@ namespace ComponentTask
                         if (this.runningTasks[i].IsFinished)
                             this.runningTasks.RemoveAt(i);
                     }
+
+                    tasksRemaining = this.runningTasks.Count > 0;
                 }
             }
+
+            return tasksRemaining;
         }
 
         /// <inheritdoc/>

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -165,6 +165,50 @@ namespace ComponentTask.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator TaskPausesWhenComponentIsDisabled()
+        {
+            var count = 0;
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+            comp.StartTask(IncrementCountAsync);
+
+            // Assert task is running.
+            yield return null;
+            Assert.AreEqual(1, count);
+
+            // Disable component.
+            comp.enabled = false;
+
+            // Assert task is paused.
+            yield return null;
+            Assert.AreEqual(1, count);
+            yield return null;
+            Assert.AreEqual(1, count);
+
+            // Enable component.
+            comp.enabled = true;
+
+            // Assert task is running.
+            yield return null;
+            Assert.AreEqual(2, count);
+            yield return null;
+            Assert.AreEqual(3, count);
+
+            // Cleanup.
+            Object.Destroy(go);
+
+            async Task IncrementCountAsync()
+            {
+                await Task.Yield();
+                count++;
+                await Task.Yield();
+                count++;
+                await Task.Yield();
+                count++;
+            }
+        }
+
+        [UnityTest]
         public IEnumerator SameRunnerIsReusedForTheSameComponent()
         {
             var go = new GameObject("TestGameObject");

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -179,6 +179,34 @@ namespace ComponentTask.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator RunnerDestroysItselfWhenComponentIsDestroyed()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+            comp.StartTask(TestAsync);
+
+            // Assert that runner was created.
+            Assert.AreEqual(2, go.GetComponents<MonoBehaviour>().Length);
+
+            // Destroy component.
+            Object.DestroyImmediate(comp);
+            yield return null;
+
+            // Assert that runner has destroyed itself.
+            Assert.AreEqual(0, go.GetComponents<MonoBehaviour>().Length);
+
+            // Cleanup.
+            yield return null;
+            Object.Destroy(go);
+
+            async Task TestAsync()
+            {
+                await Task.Yield();
+                await Task.Yield();
+            }
+        }
+
+        [UnityTest]
         public IEnumerator ThrowsWhenCalledFromNonUnityThread()
         {
             var go = new GameObject("TestGameObject");

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -207,6 +207,32 @@ namespace ComponentTask.Tests.PlayMode
         }
 
         [UnityTest]
+        public IEnumerator RunnerDestroysItselfWhenWorkIsDone()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+            comp.StartTask(TestAsync);
+
+            // Assert that runner was created.
+            Assert.AreEqual(2, go.GetComponents<MonoBehaviour>().Length);
+
+            // Wait for work to finish.
+            yield return null;
+
+            // Assert that runner has destroyed itself.
+            Assert.AreEqual(1, go.GetComponents<MonoBehaviour>().Length);
+
+            // Cleanup.
+            yield return null;
+            Object.Destroy(go);
+
+            async Task TestAsync()
+            {
+                await Task.Yield();
+            }
+        }
+
+        [UnityTest]
         public IEnumerator ThrowsWhenCalledFromNonUnityThread()
         {
             var go = new GameObject("TestGameObject");

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -240,7 +240,36 @@ namespace ComponentTask.Tests.PlayMode
             Assert.AreEqual(0, go.GetComponents<MonoBehaviour>().Length);
 
             // Cleanup.
+            Object.Destroy(go);
+
+            async Task TestAsync()
+            {
+                await Task.Yield();
+                await Task.Yield();
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator RunnerDestroysItselfWhenDisabledComponentIsDestroyed()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+            comp.StartTask(TestAsync);
+
+            // Disable component.
+            comp.enabled = false;
+
+            // Assert that runner was created.
+            Assert.AreEqual(2, go.GetComponents<MonoBehaviour>().Length);
+
+            // Destroy component.
+            Object.DestroyImmediate(comp);
             yield return null;
+
+            // Assert that runner has destroyed itself.
+            Assert.AreEqual(0, go.GetComponents<MonoBehaviour>().Length);
+
+            // Cleanup.
             Object.Destroy(go);
 
             async Task TestAsync()


### PR DESCRIPTION
Destroy runners as soon as they finish their work. 

It's a trade-of between cost of creating new runners and cost of keeping old ones alive. Reasoning for destroying them is that i've have not seen many scenarios where you start many tasks on the same component with pauses in between. If those scenarios show up we could consider making this a configurable option.

Alternative perf optimisation we could do is pooling runners.