### PR TITLE
Keep executors after work is done.

### DIFF
--- a/src/ComponentExtensions.cs
+++ b/src/ComponentExtensions.cs
@@ -427,7 +427,7 @@ namespace UnityEngine
             foreach (var runner in monoBehaviourRunners)
             {
                 // If there is a runner for that component then return that.
-                if (!runner.IsFinished && runner.RunOptions == options && runner.ComponentToFollow == component)
+                if (runner.RunOptions == options && runner.ComponentToFollow == component)
                     return runner;
             }
 

--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -18,61 +18,33 @@ namespace ComponentTask.Internal
 
         public Component ComponentToFollow { get; set; }
 
-        public bool IsFinished { get; private set; }
+        public Task StartTask(Func<Task> taskCreator) =>
+            this.taskRunner.StartTask(taskCreator);
 
-        public Task StartTask(Func<Task> taskCreator)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator);
-        }
+        public Task StartTask(Func<CancellationToken, Task> taskCreator) =>
+            this.taskRunner.StartTask(taskCreator);
 
-        public Task StartTask(Func<CancellationToken, Task> taskCreator)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator);
-        }
+        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data) =>
+            this.taskRunner.StartTask(taskCreator, data);
 
-        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator, data);
-        }
+        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data) =>
+            this.taskRunner.StartTask(taskCreator, data);
 
-        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator, data);
-        }
+        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator) =>
+            this.taskRunner.StartTask(taskCreator);
 
-        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator);
-        }
+        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator) =>
+            this.taskRunner.StartTask(taskCreator);
 
-        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator);
-        }
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data) =>
+            this.taskRunner.StartTask(taskCreator, data);
 
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator, data);
-        }
-
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data)
-        {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Task was started on already finished runner");
-            return this.taskRunner.StartTask(taskCreator, data);
-        }
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data) =>
+            this.taskRunner.StartTask(taskCreator, data);
 
         // Dynamically called from the Unity runtime.
         private void LateUpdate()
         {
-            System.Diagnostics.Debug.Assert(!this.IsFinished, "Already finished runner was updated");
-
             // Check if we have a 'ComponentToFollow' assigned.
             if (this.ComponentToFollow is null)
             {
@@ -106,20 +78,9 @@ namespace ComponentTask.Internal
         // Dynamically called from the Unity runtime.
         private void OnDestroy() => this.taskRunner.Dispose();
 
-        private void Execute()
-        {
-            var workRemaining = this.taskRunner.Execute();
+        private void Execute() => this.taskRunner.Execute();
 
-            // If we've finished all the work then destroy ourselves.
-            if (!workRemaining)
-                this.Destroy();
-        }
-
-        private void Destroy()
-        {
-            this.IsFinished = true;
-            UnityEngine.Object.Destroy(this);
-        }
+        private void Destroy() => UnityEngine.Object.Destroy(this);
 
         void IExceptionHandler.Handle(Exception exception)
         {

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -169,13 +169,11 @@ namespace ComponentTask
         /// <summary>
         /// Execute all the work that was 'scheduled' by the tasks running on this runner.
         /// </summary>
-        /// <returns>True if still running work, False if all work has finished.</returns>
-        public bool Execute()
+        public void Execute()
         {
             if (this.isDisposed)
                 throw new ObjectDisposedException(nameof(LocalTaskRunner));
 
-            bool tasksRemaining;
             try
             {
                 // Execute all the work that was scheduled on this runner.
@@ -194,12 +192,8 @@ namespace ComponentTask
                         if (this.runningTasks[i].IsFinished)
                             this.runningTasks.RemoveAt(i);
                     }
-
-                    tasksRemaining = this.runningTasks.Count > 0;
                 }
             }
-
-            return tasksRemaining;
         }
 
         /// <inheritdoc/>

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -373,32 +373,6 @@ namespace ComponentTask.Tests.PlayMode
         }
 
         [UnityTest]
-        public IEnumerator RunnerDestroysItselfWhenWorkIsDone()
-        {
-            var go = new GameObject("TestGameObject");
-            var comp = go.AddComponent<MockComponent>();
-            comp.StartTask(TestAsync);
-
-            // Assert that runner was created.
-            Assert.AreEqual(2, go.GetComponents<MonoBehaviour>().Length);
-
-            // Wait for work to finish.
-            yield return null;
-
-            // Assert that runner has destroyed itself.
-            Assert.AreEqual(1, go.GetComponents<MonoBehaviour>().Length);
-
-            // Cleanup.
-            yield return null;
-            Object.Destroy(go);
-
-            async Task TestAsync()
-            {
-                await Task.Yield();
-            }
-        }
-
-        [UnityTest]
         public IEnumerator ThrowsWhenCalledFromNonUnityThread()
         {
             var go = new GameObject("TestGameObject");


### PR DESCRIPTION
Reason is that someone could have captured the sync-context
and could post work later.