### PR TITLE
Add test for sync-context postback events pattern

### DIFF
--- a/tests/playmode/Integration/BackgroundWorkTests.cs
+++ b/tests/playmode/Integration/BackgroundWorkTests.cs
@@ -8,7 +8,7 @@ using UnityEngine.TestTools;
 
 namespace ComponentTask.Tests.PlayMode.Integration
 {
-    public sealed class BackgroundWork
+    public sealed class BackgroundWorkTests
     {
         private sealed class BackgroundWorker : MonoBehaviour
         {

--- a/tests/playmode/Integration/BackgroundWorkTests.cs.meta
+++ b/tests/playmode/Integration/BackgroundWorkTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cfcb7b6deaac3487ba5ebcc359176939
+guid: f19b330ed078c4aa6a0506b90db4da01
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/tests/playmode/Integration/DisableGameObjectAtEndTests.cs
+++ b/tests/playmode/Integration/DisableGameObjectAtEndTests.cs
@@ -7,7 +7,7 @@ using UnityEngine.TestTools;
 
 namespace ComponentTask.Tests.PlayMode.Integration
 {
-    public sealed class DisableGameObjectAtEnd
+    public sealed class DisableGameObjectAtEndTests
     {
         private sealed class ClassA : MonoBehaviour
         {

--- a/tests/playmode/Integration/DisableGameObjectAtEndTests.cs.meta
+++ b/tests/playmode/Integration/DisableGameObjectAtEndTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53b1d6fdf615645e6b551cf47fd76b5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/playmode/Integration/ProducerConsumerTests.cs
+++ b/tests/playmode/Integration/ProducerConsumerTests.cs
@@ -7,7 +7,7 @@ using UnityEngine.TestTools;
 
 namespace ComponentTask.Tests.PlayMode.Integration
 {
-    public sealed class ProducerConsumer
+    public sealed class ProducerConsumerTests
     {
         private sealed class Producer : MonoBehaviour
         {

--- a/tests/playmode/Integration/ProducerConsumerTests.cs.meta
+++ b/tests/playmode/Integration/ProducerConsumerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27f6c2c2da1344ee39d3a198dc7c7b93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tests/playmode/Integration/SynchronizationContextPostBack.cs
+++ b/tests/playmode/Integration/SynchronizationContextPostBack.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ComponentTask.Tests.PlayMode.Helpers;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace ComponentTask.Tests.PlayMode.Integration
+{
+    public sealed class SynchronizationContextPostBack
+    {
+        private sealed class TestClass : MonoBehaviour
+        {
+            private readonly ThreadedEvent threadedEvent = new ThreadedEvent();
+            private readonly List<object> receivedData = new List<object>();
+
+            public IReadOnlyList<object> ReceivedData => this.receivedData;
+
+            private void Start()
+            {
+                this.StartTask(this.RunAsync);
+            }
+
+            private async Task RunAsync()
+            {
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+
+                await Task.Yield();
+
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+                this.threadedEvent.Subscribe(this.OnWorkFinished);
+                Task.Run(this.BackgroundCalculateAsync).DontWait();
+            }
+
+            private void OnWorkFinished(object data)
+            {
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+                this.receivedData.Add(data);
+            }
+
+            private async Task BackgroundCalculateAsync()
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(42)).ConfigureAwait(false);
+                    this.threadedEvent.Invoke(i);
+                }
+            }
+        }
+
+        private sealed class ThreadedEvent
+        {
+            private readonly object listenersLock = new object();
+            private readonly List<(Action<object> callback, SynchronizationContext context)> listeners =
+                new List<(Action<object>, SynchronizationContext)>();
+
+            public void Subscribe(Action<object> callback)
+            {
+                var syncContext = SynchronizationContext.Current;
+                lock (this.listenersLock)
+                {
+                    this.listeners.Add((callback, syncContext));
+                }
+            }
+
+            public void Invoke(object data)
+            {
+                lock (this.listenersLock)
+                {
+                    foreach (var listener in this.listeners)
+                        listener.context.Post(s => listener.callback(s), data);
+                }
+            }
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            TraceAsserter.Register();
+        }
+
+        [UnityTest]
+        public IEnumerator SynchronizationPostBacksAreDelivered()
+        {
+            /* This test simulates a pattern where you 'subscribe' to a 'event' but that event
+            captures the sync-context and 'invokes' the event there. This is a pretty common pattern
+            to handle events in a multi-threaded environment.*/
+
+            var go = new GameObject("TestClass");
+            var testClass = go.AddComponent<TestClass>();
+
+            // Wait for the work to finish.
+            yield return new WaitForSeconds(1f);
+
+            CollectionAssert.AreEquivalent(new object[] { 0, 1, 2, 3, 4 }, testClass.ReceivedData);
+
+            // Cleanup.
+            UnityEngine.Object.Destroy(go);
+        }
+    }
+}

--- a/tests/playmode/Integration/SynchronizationContextPostBack.cs.meta
+++ b/tests/playmode/Integration/SynchronizationContextPostBack.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 65d4ac4bba226427dba450d94889316d
+guid: 4a8f955c9802d449a8080aa30340b5f0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/tests/playmode/Integration/SynchronizationContextPostBackTests.cs
+++ b/tests/playmode/Integration/SynchronizationContextPostBackTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ComponentTask.Tests.PlayMode.Helpers;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace ComponentTask.Tests.PlayMode.Integration
+{
+    public sealed class SynchronizationContextPostBackTests
+    {
+        private sealed class TestClass : MonoBehaviour
+        {
+            private readonly ThreadedEvent threadedEvent = new ThreadedEvent();
+            private readonly List<object> receivedData = new List<object>();
+
+            public IReadOnlyList<object> ReceivedData => this.receivedData;
+
+            private void Start() => this.StartTask(this.RunAsync);
+
+            private async Task RunAsync()
+            {
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+
+                await Task.Yield();
+
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+                this.threadedEvent.Subscribe(this.OnWorkFinished);
+                Task.Run(this.BackgroundCalculateAsync).DontWait();
+            }
+
+            private void OnWorkFinished(object data)
+            {
+                ComponentContextAsserter.AssertRunningInComponentContext(this);
+                this.receivedData.Add(data);
+            }
+
+            private async Task BackgroundCalculateAsync()
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(42)).ConfigureAwait(false);
+                    this.threadedEvent.Invoke(i);
+                }
+            }
+        }
+
+        private sealed class ThreadedEvent
+        {
+            private readonly object listenersLock = new object();
+            private readonly List<(Action<object> callback, SynchronizationContext context)> listeners =
+                new List<(Action<object>, SynchronizationContext)>();
+
+            public void Subscribe(Action<object> callback)
+            {
+                var syncContext = SynchronizationContext.Current;
+                lock (this.listenersLock)
+                {
+                    this.listeners.Add((callback, syncContext));
+                }
+            }
+
+            public void Invoke(object data)
+            {
+                lock (this.listenersLock)
+                {
+                    foreach (var listener in this.listeners)
+                        listener.context.Post(s => listener.callback(s), data);
+                }
+            }
+        }
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            TraceAsserter.Register();
+        }
+
+        [UnityTest]
+        public IEnumerator SynchronizationPostBacksAreDelivered()
+        {
+            /* This test simulates a pattern where you 'subscribe' to a 'event' but that event
+            captures the sync-context and 'invokes' the event there. This is a pretty common pattern
+            to handle events in a multi-threaded environment.*/
+
+            var go = new GameObject("TestClass");
+            var testClass = go.AddComponent<TestClass>();
+
+            // Wait for the work to finish.
+            yield return new WaitForSeconds(1f);
+
+            CollectionAssert.AreEquivalent(new object[] { 0, 1, 2, 3, 4 }, testClass.ReceivedData);
+
+            // Cleanup.
+            UnityEngine.Object.Destroy(go);
+        }
+    }
+}

--- a/tests/playmode/Integration/SynchronizationContextPostBackTests.cs.meta
+++ b/tests/playmode/Integration/SynchronizationContextPostBackTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c913a65cb0da2431894cfa56799e84da
+guid: 40a270cd934f24e6daa699e7441c0596
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/tests/playmode/Integration/WrappingTasksTests.cs
+++ b/tests/playmode/Integration/WrappingTasksTests.cs
@@ -8,7 +8,7 @@ using UnityEngine.TestTools;
 
 namespace ComponentTask.Tests.PlayMode.Integration
 {
-    public sealed class WrappingTasks
+    public sealed class WrappingTasksTests
     {
         private sealed class ClassA : MonoBehaviour
         {

--- a/tests/playmode/Integration/WrappingTasksTests.cs.meta
+++ b/tests/playmode/Integration/WrappingTasksTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5bc77c6e199754b258727b4277a588de
+guid: 80799f292801d4a4da2a352b67db0a9d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Adds a test for a pretty common pattern where a 'even-like' class captures the sync-context to call you back on later.