### PR TITLE
Feature/threading stress tests

### DIFF
--- a/tests/editmode/LocalTaskRunner_ThreadingTests.cs
+++ b/tests/editmode/LocalTaskRunner_ThreadingTests.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ComponentTask.Tests.EditMode.Helpers;
+using ComponentTask.Tests.EditMode.Mocks;
+using NUnit.Framework;
+
+namespace ComponentTask.Tests.EditMode
+{
+    public sealed class LocalTaskRunner_ThreadingTests
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            TraceAsserter.Register();
+        }
+
+        [Test]
+        public void CallbackPostThreadingStressTest()
+        {
+            var exHandler = new MockExceptionHandler();
+            using (var runner = new LocalTaskRunner(exHandler))
+            {
+                // Start the stress tasks.
+                for (int i = 0; i < 100; i++)
+                    runner.StartTask(StressAsync);
+
+                // Execute enough times to finish all tasks.
+                for (int i = 0; i < 999; i++)
+                {
+                    runner.Execute();
+                    Thread.Yield();
+                }
+
+                // Assert that all tasks have finished.
+                runner.AssertRunningTaskCount(0);
+            }
+
+            async Task StressAsync()
+            {
+                /* This stresses the sync-context by posting callbacks from many different threads. */
+                for (int i = 0; i < 100; i++)
+                    await Task.Run(() => Thread.Yield());
+            }
+        }
+    }
+}

--- a/tests/editmode/LocalTaskRunner_ThreadingTests.cs
+++ b/tests/editmode/LocalTaskRunner_ThreadingTests.cs
@@ -72,5 +72,31 @@ namespace ComponentTask.Tests.EditMode
                     await Task.Yield();
             }
         }
+
+        [Test]
+        public void StartTaskThreadingStressTest()
+        {
+            var exHandler = new MockExceptionHandler();
+            using (var runner = new LocalTaskRunner(exHandler))
+            {
+                // Start many tasks tasks in parallel.
+                for (int i = 0; i < 100; i++)
+                    ThreadPool.QueueUserWorkItem(r => ((LocalTaskRunner)r).StartTask(TestAsync), runner);
+
+                // Wait for tasks to start.
+                Thread.Sleep(millisecondsTimeout: 1000);
+
+                // Execute a single tick to finish all tasks.
+                runner.Execute();
+
+                // Assert that all tasks have finished.
+                runner.AssertRunningTaskCount(0);
+            }
+
+            async Task TestAsync()
+            {
+                await Task.Yield();
+            }
+        }
     }
 }

--- a/tests/editmode/LocalTaskRunner_ThreadingTests.cs
+++ b/tests/editmode/LocalTaskRunner_ThreadingTests.cs
@@ -21,14 +21,14 @@ namespace ComponentTask.Tests.EditMode
             using (var runner = new LocalTaskRunner(exHandler))
             {
                 // Start the stress tasks.
-                for (int i = 0; i < 100; i++)
+                for (int i = 0; i < 50; i++)
                     runner.StartTask(StressAsync);
 
                 // Execute enough times to finish all tasks.
-                for (int i = 0; i < 999; i++)
+                for (int i = 0; i < 99; i++)
                 {
                     runner.Execute();
-                    Thread.Yield();
+                    Thread.Sleep(10);
                 }
 
                 // Assert that all tasks have finished.
@@ -38,8 +38,38 @@ namespace ComponentTask.Tests.EditMode
             async Task StressAsync()
             {
                 /* This stresses the sync-context by posting callbacks from many different threads. */
-                for (int i = 0; i < 100; i++)
+                for (int i = 0; i < 50; i++)
                     await Task.Run(() => Thread.Yield());
+            }
+        }
+
+        [Test]
+        public void ExecuteThreadingStressTest()
+        {
+            var exHandler = new MockExceptionHandler();
+            using (var runner = new LocalTaskRunner(exHandler))
+            {
+                // Start many tasks tasks.
+                for (int i = 0; i < 100; i++)
+                    runner.StartTask(TestAsync);
+
+                for (int interation = 0; interation < 11; interation++)
+                {
+                    // Execute from many different threads in parallel.
+                    for (int thread = 0; thread < 100; thread++)
+                        ThreadPool.QueueUserWorkItem(r => ((LocalTaskRunner)r).Execute(), runner);
+
+                    Thread.Sleep(millisecondsTimeout: 100);
+                }
+
+                // Assert that all tasks have finished.
+                runner.AssertRunningTaskCount(0);
+            }
+
+            async Task TestAsync()
+            {
+                for (int i = 0; i < 10; i++)
+                    await Task.Yield();
             }
         }
     }

--- a/tests/editmode/LocalTaskRunner_ThreadingTests.cs.meta
+++ b/tests/editmode/LocalTaskRunner_ThreadingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 90e20d5b176ff4b62adca415b7548cb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add some tests to test thread-safety of `LocalTaskRunner`. By no means guarantees thread-safety but hopefully over time this will 'prove' that its thread-safe.