### PR TITLE
Diagnostic logging

### DIFF
--- a/.example/Assets/AvoidingClosures/Scene.unity
+++ b/.example/Assets/AvoidingClosures/Scene.unity
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,6 +95,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -121,6 +129,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 239404747}
+  - component: {fileID: 239404748}
   m_Layer: 0
   m_Name: MyClassWithValueTuple
   m_TagString: Untagged
@@ -142,6 +151,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &239404748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 239404746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dbcabbdfd29ce44d08009df272185f42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &371565987
 GameObject:
   m_ObjectHideFlags: 0
@@ -152,7 +173,6 @@ GameObject:
   m_Component:
   - component: {fileID: 371565990}
   - component: {fileID: 371565989}
-  - component: {fileID: 371565988}
   m_Layer: 0
   m_Name: MyClass
   m_TagString: Untagged
@@ -160,18 +180,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &371565988
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 371565987}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dbcabbdfd29ce44d08009df272185f42, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &371565989
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,12 +231,13 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 388771378}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 9
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -238,6 +247,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -245,12 +272,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &388771380
@@ -305,9 +335,10 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2

--- a/.example/Assets/Threading/Scene.unity
+++ b/.example/Assets/Threading/Scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.49641287, b: 0.5748173, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -62,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -76,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,6 +95,7 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
     m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -150,9 +158,10 @@ Camera:
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -219,12 +228,13 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1115871289}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 9
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -234,6 +244,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -241,12 +269,15 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 4
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1115871291
@@ -263,3 +294,46 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1162654771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1162654773}
+  - component: {fileID: 1162654772}
+  m_Layer: 0
+  m_Name: MyClass
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1162654772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1162654771}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b8b302b7d1e44f569e216d887c64f91, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1162654773
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1162654771}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/README.md
+++ b/README.md
@@ -256,6 +256,13 @@ class MyClass : MonoBehaviour
 Even though `VeryExpensiveBlockingCode` blocks for 5 seconds because we run it on a background-thread
 (with [Task.Run](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.run)) the unity-thread stays responsive.
 
+## Debugging
+To help in debugging you can give the `TaskRunOptions.DiagnosticLogging` flag when starting a task
+to enable log output for that task.
+
+Alternatively if you want to enable logging for all tasks you can set it globally:
+`ComponentTask.Config.GlobalDiagnosticsActive`.
+
 ## Apis
 So far we've been starting tasks using extension methods on `UnityEngine.Component`:
 ```c#

--- a/src/ComponentExtensions.cs
+++ b/src/ComponentExtensions.cs
@@ -422,6 +422,9 @@ namespace UnityEngine
         {
             var owner = component.gameObject;
 
+            // Apply the global configuration to the options.
+            options = Config.Apply(options);
+
             // Check if there is a existing runner for the same scope.
             owner.GetComponents<MonoBehaviourTaskRunner>(monoBehaviourRunners);
             foreach (var runner in monoBehaviourRunners)

--- a/src/ComponentTask/Config.cs
+++ b/src/ComponentTask/Config.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+namespace ComponentTask
+{
+    /// <summary>
+    /// Global configuration.
+    /// </summary>
+    public static class Config
+    {
+        /// <summary>
+        /// Should diagnostics be enabled.
+        /// </summary>
+        /// <remarks>
+        /// Runs all tasks with the '<see cref="TaskRunOptions.DiagnosticLogging"/>' flag.
+        /// </remarks>
+        /// <value>True if diagnostics are active, otherwise false.</value>
+        public static bool GlobalDiagnosticsActive { get; set; }
+
+        /// <summary>
+        /// Modify run-options based on the global config.
+        /// </summary>
+        /// <param name="options">Options to modify.</param>
+        /// <returns>Modified options.</returns>
+        internal static TaskRunOptions Apply(TaskRunOptions options)
+        {
+            if (GlobalDiagnosticsActive)
+                options |= TaskRunOptions.DiagnosticLogging;
+
+            return options;
+        }
+    }
+}

--- a/src/ComponentTask/Config.cs.meta
+++ b/src/ComponentTask/Config.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cfb3026de028742a298482185b14f164
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/IDiagnosticLogger.cs
+++ b/src/ComponentTask/IDiagnosticLogger.cs
@@ -1,0 +1,14 @@
+namespace ComponentTask
+{
+    /// <summary>
+    /// Interface for logging diagnostic output.
+    /// </summary>
+    public interface IDiagnosticLogger
+    {
+        /// <summary>
+        /// Log a diagnostic message.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        void Log(string message);
+    }
+}

--- a/src/ComponentTask/IDiagnosticLogger.cs.meta
+++ b/src/ComponentTask/IDiagnosticLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 059420a281ab541f28b3c6ecdb255441
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Internal/DelegateExtensions.cs
+++ b/src/ComponentTask/Internal/DelegateExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace ComponentTask.Internal
+{
+    internal static class DelegateExtensions
+    {
+        /// <summary>
+        /// Get a diagnostic identifier that best describes this delegate.
+        /// </summary>
+        /// <remarks>
+        /// Only meant for diagnostic purposes, do NOT depend on output being in a specific format.
+        /// </remarks>
+        /// <param name="@delegate">Delegate to get an identifier for.</param>
+        /// <returns>Identifier best describing the given delegate.</returns>
+        public static string GetDiagIdentifier(this Delegate @delegate)
+        {
+            if (@delegate is null)
+                throw new ArgumentNullException(nameof(@delegate));
+
+            try
+            {
+                var method = @delegate.Method;
+                var owner = method.DeclaringType;
+                return $"{owner.Name}.{method.Name}";
+            }
+            catch (MemberAccessException)
+            {
+                if (@delegate.Target != null)
+                    return $"{@delegate.Target.GetType().Name}.<private>";
+                return "<private>";
+            }
+        }
+    }
+}

--- a/src/ComponentTask/Internal/DelegateExtensions.cs.meta
+++ b/src/ComponentTask/Internal/DelegateExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87902d874e77d42bfb843cc497a416dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Internal/DiagTaskTracer.cs
+++ b/src/ComponentTask/Internal/DiagTaskTracer.cs
@@ -20,6 +20,12 @@ namespace ComponentTask.Internal
         public void LogInvoked(object argument = null) =>
             this.logger.Log($"{identifier} -> Invoking (argument: '{argument?.ToString() ?? "none"}').");
 
+        public void LogPaused() =>
+            this.logger.Log($"{identifier} -> Paused.");
+
+        public void LogResumed() =>
+            this.logger.Log($"{identifier} -> Resumed.");
+
         public void LogCompletedSynchronouslyAsSuccess(object result) =>
             this.logger.Log($"{identifier} -> Completed synchronously: Success (result: '{result?.ToString() ?? "none"}').");
 

--- a/src/ComponentTask/Internal/DiagTaskTracer.cs
+++ b/src/ComponentTask/Internal/DiagTaskTracer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ComponentTask.Internal
+{
+    internal sealed class DiagTaskTracer
+    {
+        private readonly string identifier;
+        private readonly IDiagnosticLogger logger;
+
+        private DiagTaskTracer(IDiagnosticLogger logger, string identifier)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(identifier), "Invalid identifier");
+            Debug.Assert(logger != null, "Logger is null");
+
+            this.identifier = identifier;
+            this.logger = logger;
+        }
+
+        public void LogInvoked(object argument = null) =>
+            this.logger.Log($"{identifier} -> Invoking (argument: '{argument?.ToString() ?? "none"}').");
+
+        public void LogCompletedSynchronouslyAsSuccess(object result) =>
+            this.logger.Log($"{identifier} -> Completed synchronously: Success (result: '{result?.ToString() ?? "none"}').");
+
+        public void LogCompletedSynchronouslyAsFaulted(Exception exception) =>
+            this.logger.Log($"{identifier} -> Completed synchronously: Faulted (exception: '{exception?.Message ?? "none"}').");
+
+        public void LogCompletedSynchronouslyAsCanceled() =>
+            this.logger.Log($"{identifier} -> Completed synchronously: Canceled.");
+
+        public void LogStartRunning() =>
+            this.logger.Log($"{identifier} -> Started running asynchronously.");
+
+        public void LogCompletedAsSuccess(object result) =>
+            this.logger.Log($"{identifier} -> Completed: Success (result: '{result?.ToString() ?? "none"}').");
+
+        public void LogCompletedAsFaulted(Exception exception) =>
+            this.logger.Log($"{identifier} -> Completed: Faulted (exception: '{exception?.Message ?? "none"}').");
+
+        public void LogCompletedAsCanceled() =>
+            this.logger.Log($"{identifier} -> Completed: Canceled.");
+
+        public void LogCanceled() =>
+            this.logger.Log($"{identifier} -> Canceled.");
+
+        public static DiagTaskTracer Create(IDiagnosticLogger logger, Delegate taskCreator)
+        {
+            if (logger is null)
+                throw new ArgumentNullException(nameof(logger));
+            if (taskCreator is null)
+                throw new ArgumentNullException(nameof(taskCreator));
+
+            return new DiagTaskTracer(logger, taskCreator.GetDiagIdentifier());
+        }
+    }
+}

--- a/src/ComponentTask/Internal/DiagTaskTracer.cs.meta
+++ b/src/ComponentTask/Internal/DiagTaskTracer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 906ab069eef3c4f10b50d8970108108e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Internal/EnumerableExtensions.cs
+++ b/src/ComponentTask/Internal/EnumerableExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ComponentTask.Internal
+{
+    internal static class EnumerableExtensions
+    {
+        private static class ThreadStatic<T>
+        {
+            [ThreadStatic] public static List<T> invokeList;
+        }
+
+        /// <summary>
+        /// Invoke the given action on all the items in the enumerable while holding the lock.
+        /// </summary>
+        /// <param name="enumerable">Enumerable with entries to invoke the action on.</param>
+        /// <param name="lockObject">Object to lock on while iterating the enumerable.</param>
+        /// <param name="action">Action to invoke on the entries.</param>
+        public static void LockedInvoke<T>(this IEnumerable<T> enumerable, object lockObject, Action<T> action)
+        {
+            if (enumerable is null)
+                throw new ArgumentNullException(nameof(enumerable));
+            if (lockObject is null)
+                throw new ArgumentNullException(nameof(lockObject));
+            if (action is null)
+                throw new ArgumentNullException(nameof(action));
+
+            /*
+            This first gathers all items in a separate collection before invoking, two reasons for this:
+            1: We hold the lock for as short a time as possible.
+            2: We avoid calling 'external' code while holding a lock (which could potentially deadlock.
+            */
+
+            // Get a thread-static list to use.
+            if (ThreadStatic<T>.invokeList is null)
+                ThreadStatic<T>.invokeList = new List<T>();
+            else
+                ThreadStatic<T>.invokeList.Clear();
+
+            // Gather all items to invoke while holding the lock.
+            lock (lockObject)
+            {
+                foreach (var val in enumerable)
+                    ThreadStatic<T>.invokeList.Add(val);
+            }
+
+            foreach (var invokeVal in ThreadStatic<T>.invokeList)
+                action.Invoke(invokeVal);
+        }
+    }
+}

--- a/src/ComponentTask/Internal/EnumerableExtensions.cs.meta
+++ b/src/ComponentTask/Internal/EnumerableExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f684f0dd9d3dd499b88fd34bbcdc3e01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Internal/ITaskHandle.cs
+++ b/src/ComponentTask/Internal/ITaskHandle.cs
@@ -4,6 +4,8 @@ namespace ComponentTask.Internal
     {
         bool IsCompleted { get; }
 
+        DiagTaskTracer DiagTracer { get; }
+
         bool TryCancel();
     }
 }

--- a/src/ComponentTask/Internal/ITaskHandle.cs
+++ b/src/ComponentTask/Internal/ITaskHandle.cs
@@ -2,7 +2,7 @@ namespace ComponentTask.Internal
 {
     internal interface ITaskHandle
     {
-        bool IsFinished { get; }
+        bool IsCompleted { get; }
 
         bool TryCancel();
     }

--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -73,16 +73,6 @@ namespace ComponentTask.Internal
         }
 
         // Dynamically called from the Unity runtime.
-        private void OnEnable()
-        {
-            if (this.isPaused)
-            {
-                this.isPaused = false;
-                this.LogResume();
-            }
-        }
-
-        // Dynamically called from the Unity runtime.
         private void OnDisable()
         {
             /* Unfortunately this is also called when the gameobject is destroyed, so far i have not
@@ -117,7 +107,17 @@ namespace ComponentTask.Internal
                         var updateWhileDisabled =
                             (this.RunOptions & TaskRunOptions.UpdateWhileComponentDisabled) == TaskRunOptions.UpdateWhileComponentDisabled;
                         if (updateWhileDisabled || behaviour.isActiveAndEnabled)
+                        {
                             this.Execute();
+                        }
+                        else
+                        {
+                            if (!this.isPaused)
+                            {
+                                this.LogPause();
+                                this.isPaused = true;
+                            }
+                        }
                     }
                     else
                     {
@@ -131,7 +131,16 @@ namespace ComponentTask.Internal
         // Dynamically called from the Unity runtime.
         private void OnDestroy() => this.taskRunner.Dispose();
 
-        private void Execute() => this.taskRunner.Execute();
+        private void Execute()
+        {
+            if (this.isPaused)
+            {
+                this.LogResume();
+                this.isPaused = false;
+            }
+
+            this.taskRunner.Execute();
+        }
 
         private void Destroy() => UnityEngine.Object.Destroy(this);
 

--- a/src/ComponentTask/Internal/TaskHandle.cs
+++ b/src/ComponentTask/Internal/TaskHandle.cs
@@ -12,59 +12,62 @@ namespace ComponentTask.Internal
             Debug.Assert(state is TaskHandle, "State does not contain TaskHandle");
             var handle = (TaskHandle)state;
 
-            handle.isFinished = true;
             if (task.IsFaulted)
             {
-                try
+                if (handle.completeSource.TrySetException(task.Exception))
                 {
                     handle.exceptionHandler.HandleAll(task.Exception);
-                }
-                finally
-                {
-                    handle.completeSource.TrySetException(task.Exception);
+                    handle.diagTracer?.LogCompletedAsFaulted(task.Exception);
                 }
             }
             else
             if (task.IsCanceled)
             {
-                try
+                if (handle.completeSource.TrySetCanceled())
                 {
                     // Log a exception to avoid silent failures.
                     handle.exceptionHandler.Handle(new ComponentTaskCanceledException());
-                }
-                finally
-                {
-                    handle.completeSource.TrySetCanceled();
+                    handle.diagTracer?.LogCompletedAsCanceled();
                 }
             }
             else
             if (task.IsCompleted)
-                handle.completeSource.TrySetResult(default);
+            {
+                if (handle.completeSource.TrySetResult(default))
+                {
+                    handle.diagTracer?.LogCompletedAsSuccess(default);
+                }
+            }
             else
                 Debug.Fail("Invalid state");
         };
 
         private readonly TaskCompletionSource<object> completeSource;
         private readonly IExceptionHandler exceptionHandler;
+        private readonly DiagTaskTracer diagTracer;
 
-        private volatile bool isFinished;
-
-        public TaskHandle(IExceptionHandler exceptionHandler)
+        public TaskHandle(IExceptionHandler exceptionHandler, DiagTaskTracer diagTracer)
         {
             Debug.Assert(exceptionHandler != null, "No exception handler provided");
 
             this.completeSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.exceptionHandler = exceptionHandler;
+            this.diagTracer = diagTracer;
         }
 
         public Task Task => this.completeSource.Task;
 
-        public bool IsFinished => this.isFinished;
+        public bool IsCompleted => this.completeSource.Task.IsCompleted;
 
         public bool TryCancel()
         {
-            this.isFinished = true;
-            return this.completeSource.TrySetCanceled();
+            if (this.completeSource.TrySetCanceled())
+            {
+                this.diagTracer?.LogCanceled();
+                return true;
+            }
+
+            return false;
         }
     }
 
@@ -75,59 +78,62 @@ namespace ComponentTask.Internal
             Debug.Assert(state is TaskHandle<T>, "State does not contain TaskHandle<T>");
             var handle = (TaskHandle<T>)state;
 
-            handle.isFinished = true;
             if (task.IsFaulted)
             {
-                try
+                if (handle.completeSource.TrySetException(task.Exception))
                 {
                     handle.exceptionHandler.HandleAll(task.Exception);
-                }
-                finally
-                {
-                    handle.completeSource.TrySetException(task.Exception);
+                    handle.diagTracer?.LogCompletedAsFaulted(task.Exception);
                 }
             }
             else
             if (task.IsCanceled)
             {
-                try
+                if (handle.completeSource.TrySetCanceled())
                 {
                     // Log a exception to avoid silent failures.
                     handle.exceptionHandler.Handle(new ComponentTaskCanceledException());
-                }
-                finally
-                {
-                    handle.completeSource.TrySetCanceled();
+                    handle.diagTracer?.LogCompletedAsCanceled();
                 }
             }
             else
             if (task.IsCompleted)
-                handle.completeSource.TrySetResult(task.Result);
+            {
+                if (handle.completeSource.TrySetResult(task.Result))
+                {
+                    handle.diagTracer.LogCompletedAsSuccess(task.Result);
+                }
+            }
             else
                 Debug.Fail("Invalid state");
         };
 
         private readonly TaskCompletionSource<T> completeSource;
         private readonly IExceptionHandler exceptionHandler;
+        private readonly DiagTaskTracer diagTracer;
 
-        private volatile bool isFinished;
-
-        public TaskHandle(IExceptionHandler exceptionHandler)
+        public TaskHandle(IExceptionHandler exceptionHandler, DiagTaskTracer diagTracer)
         {
             Debug.Assert(exceptionHandler != null, "No exception handler provided");
 
             this.completeSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.exceptionHandler = exceptionHandler;
+            this.diagTracer = diagTracer;
         }
 
         public Task<T> Task => this.completeSource.Task;
 
-        public bool IsFinished => this.isFinished;
+        public bool IsCompleted => this.completeSource.Task.IsCompleted;
 
         public bool TryCancel()
         {
-            this.isFinished = true;
-            return this.completeSource.TrySetCanceled();
+            if (this.completeSource.TrySetCanceled())
+            {
+                this.diagTracer?.LogCanceled();
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/ComponentTask/Internal/TaskHandle.cs
+++ b/src/ComponentTask/Internal/TaskHandle.cs
@@ -59,6 +59,8 @@ namespace ComponentTask.Internal
 
         public bool IsCompleted => this.completeSource.Task.IsCompleted;
 
+        public DiagTaskTracer DiagTracer => this.diagTracer;
+
         public bool TryCancel()
         {
             if (this.completeSource.TrySetCanceled())
@@ -122,6 +124,8 @@ namespace ComponentTask.Internal
         }
 
         public Task<T> Task => this.completeSource.Task;
+
+        public DiagTaskTracer DiagTracer => this.diagTracer;
 
         public bool IsCompleted => this.completeSource.Task.IsCompleted;
 

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -287,6 +287,16 @@ namespace ComponentTask
             }
         }
 
+        /// <summary>
+        /// Invoke given action on each running task.
+        /// </summary>
+        /// <summary>
+        /// Note: Internal as it exposes allot of implementation details.
+        /// </summary>
+        /// <param name="action">Action to invoke on each running task.</param>
+        internal void ForAllRunningTasks(Action<ITaskHandle> action) =>
+            this.runningTasks.LockedInvoke(this.runningTasksLock, action);
+
         private Task WrapTask(Task task, DiagTaskTracer diagTracer)
         {
             if (task is null)

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -47,7 +47,14 @@ namespace ComponentTask
         }
 
         /// <inheritdoc/>
-        public Task StartTask(Func<Task> taskCreator)
+        public Task StartTask(Func<Task> taskCreator) =>
+            this.StartTask(taskCreator, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask(Func{Task})"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task StartTask(
+            Func<Task> taskCreator,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -57,12 +64,21 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask(taskCreator.Invoke());
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked();
+                return this.WrapTask(taskCreator.Invoke(), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task StartTask(Func<CancellationToken, Task> taskCreator)
+        public Task StartTask(Func<CancellationToken, Task> taskCreator) =>
+            this.StartTask(taskCreator, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask(Func{CancellationToken, Task})"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task StartTask(
+            Func<CancellationToken, Task> taskCreator,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -72,12 +88,22 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask(taskCreator.Invoke(this.cancelSource.Token));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked();
+                return this.WrapTask(taskCreator.Invoke(this.cancelSource.Token), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data)
+        public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data) =>
+            this.StartTask(taskCreator, data, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TIn}(Func{TIn, Task}, TIn)"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task StartTask<TIn>(
+            Func<TIn, Task> taskCreator,
+            TIn data,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -87,12 +113,22 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask(taskCreator.Invoke(data));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked(data);
+                return this.WrapTask(taskCreator.Invoke(data), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data)
+        public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data) =>
+            this.StartTask(taskCreator, data, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TIn}(Func{TIn, CancellationToken, Task}, TIn)"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task StartTask<TIn>(
+            Func<TIn, CancellationToken, Task> taskCreator,
+            TIn data,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -102,12 +138,21 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask(taskCreator.Invoke(data, this.cancelSource.Token));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked(data);
+                return this.WrapTask(taskCreator.Invoke(data, this.cancelSource.Token), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator)
+        public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator) =>
+            this.StartTask(taskCreator, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TOut}(Func{Task{TOut}})"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task<TOut> StartTask<TOut>(
+            Func<Task<TOut>> taskCreator,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -117,12 +162,21 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask<TOut>(taskCreator.Invoke());
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked();
+                return this.WrapTask<TOut>(taskCreator.Invoke(), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator)
+        public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator) =>
+            this.StartTask(taskCreator, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TOut}(Func{CancellationToken, Task{TOut}})"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task<TOut> StartTask<TOut>(
+            Func<CancellationToken, Task<TOut>> taskCreator,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -132,12 +186,22 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask<TOut>(taskCreator.Invoke(this.cancelSource.Token));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked();
+                return this.WrapTask<TOut>(taskCreator.Invoke(this.cancelSource.Token), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data)
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data) =>
+            this.StartTask(taskCreator, data, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TIn, TOut}(Func{TIn, Task{TOut}}, TIn)"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task<TOut> StartTask<TIn, TOut>(
+            Func<TIn, Task<TOut>> taskCreator,
+            TIn data,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -147,12 +211,22 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask<TOut>(taskCreator.Invoke(data));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked(data);
+                return this.WrapTask<TOut>(taskCreator.Invoke(data), diagTracer);
             }
         }
 
         /// <inheritdoc/>
-        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data)
+        public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data) =>
+            this.StartTask(taskCreator, data, logger: null);
+
+        /// <inheritdoc cref="ITaskRunner.StartTask{TIn, TOut}(Func{TIn, CancellationToken, Task{TOut}}, TIn)"/>
+        /// <param name="logger">Optional logger to output diagnostic messages to.</param>
+        public Task<TOut> StartTask<TIn, TOut>(
+            Func<TIn, CancellationToken, Task<TOut>> taskCreator,
+            TIn data,
+            IDiagnosticLogger logger)
         {
             if (taskCreator is null)
                 throw new ArgumentNullException(nameof(taskCreator));
@@ -162,7 +236,9 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                return this.WrapTask<TOut>(taskCreator.Invoke(data, this.cancelSource.Token));
+                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                diagTracer?.LogInvoked(data);
+                return this.WrapTask<TOut>(taskCreator.Invoke(data, this.cancelSource.Token), diagTracer);
             }
         }
 
@@ -189,7 +265,7 @@ namespace ComponentTask
                 {
                     for (int i = this.runningTasks.Count - 1; i >= 0; i--)
                     {
-                        if (this.runningTasks[i].IsFinished)
+                        if (this.runningTasks[i].IsCompleted)
                             this.runningTasks.RemoveAt(i);
                     }
                 }
@@ -211,7 +287,7 @@ namespace ComponentTask
             }
         }
 
-        private Task WrapTask(Task task)
+        private Task WrapTask(Task task, DiagTaskTracer diagTracer)
         {
             if (task is null)
                 throw new TaskCreatorReturnedNullException();
@@ -219,12 +295,15 @@ namespace ComponentTask
             // Handle exceptions that are thrown in the synchronous part.
             if (task.IsFaulted)
             {
+                diagTracer?.LogCompletedSynchronouslyAsFaulted(task.Exception);
                 this.exceptionHandler.HandleAll(task.Exception);
                 return task;
             }
 
             if (task.IsCanceled)
             {
+                diagTracer?.LogCompletedSynchronouslyAsCanceled();
+
                 // Log a exception to avoid silent failures.
                 this.exceptionHandler.Handle(new ComponentTaskCanceledException());
                 return task;
@@ -232,17 +311,23 @@ namespace ComponentTask
 
             // Fast path if the task completes synchronously.
             if (task.IsCompleted)
+            {
+                diagTracer?.LogCompletedSynchronouslyAsSuccess(default);
+
                 return task;
+            }
+
+            diagTracer?.LogStartRunning();
 
             // Create handle and complete it when the given task completes.
-            var handle = new TaskHandle(this.exceptionHandler);
+            var handle = new TaskHandle(this.exceptionHandler, diagTracer);
             task.ContinueWith(TaskHandle.UpdateFromTask, handle, TaskContinuationOptions.ExecuteSynchronously);
 
             this.RegisterTaskHandle(handle);
             return handle.Task;
         }
 
-        private Task<T> WrapTask<T>(Task<T> task)
+        private Task<T> WrapTask<T>(Task<T> task, DiagTaskTracer diagTracer)
         {
             if (task is null)
                 throw new TaskCreatorReturnedNullException();
@@ -250,6 +335,7 @@ namespace ComponentTask
             // Handle exceptions that are thrown in the synchronous part.
             if (task.IsFaulted)
             {
+                diagTracer?.LogCompletedSynchronouslyAsFaulted(task.Exception);
                 this.exceptionHandler.HandleAll(task.Exception);
                 return task;
             }
@@ -257,6 +343,8 @@ namespace ComponentTask
             // Log a 'OperationCanceledException' to avoid silent failures.
             if (task.IsCanceled)
             {
+                diagTracer?.LogCompletedSynchronouslyAsCanceled();
+
                 // Log a exception to avoid silent failures.
                 this.exceptionHandler.Handle(new ComponentTaskCanceledException());
                 return task;
@@ -264,10 +352,15 @@ namespace ComponentTask
 
             // Fast path if the task completes synchronously.
             if (task.IsCompleted)
+            {
+                diagTracer?.LogCompletedSynchronouslyAsSuccess(task.Result);
                 return task;
+            }
+
+            diagTracer?.LogStartRunning();
 
             // Create handle and complete it when the given task completes.
-            var handle = new TaskHandle<T>(this.exceptionHandler);
+            var handle = new TaskHandle<T>(this.exceptionHandler, diagTracer);
             task.ContinueWith(TaskHandle<T>.UpdateFromTask, handle, TaskContinuationOptions.ExecuteSynchronously);
 
             this.RegisterTaskHandle(handle);

--- a/src/GameObjectExtensions.cs
+++ b/src/GameObjectExtensions.cs
@@ -38,7 +38,7 @@ namespace UnityEngine
 
             // Create runner.
             var runner = gameObject.AddComponent<MonoBehaviourTaskRunner>();
-            runner.RunOptions = options;
+            runner.RunOptions = Config.Apply(options);
             runner.hideFlags = HideFlags.HideInInspector;
 
             return runner;

--- a/src/GameObjectExtensions.cs
+++ b/src/GameObjectExtensions.cs
@@ -24,8 +24,11 @@ namespace UnityEngine
         /// Thrown when called from a non-unity thread.
         /// </exception>
         /// <param name="gameObject">GameObject to create the task-runner on.</param>
+        /// <param name="options">Options for configuring how tasks are run on this runner.</param>
         /// <returns>Newly created <see cref="ITaskRunner"/>.</returns>
-        public static ITaskRunner CreateTaskRunner(this GameObject gameObject)
+        public static ITaskRunner CreateTaskRunner(
+            this GameObject gameObject,
+            TaskRunOptions options = TaskRunOptions.Default)
         {
             // Validate params.
             UnityHelper.ThrowForInvalidObjectParam(gameObject, nameof(gameObject));
@@ -35,7 +38,7 @@ namespace UnityEngine
 
             // Create runner.
             var runner = gameObject.AddComponent<MonoBehaviourTaskRunner>();
-            runner.RunOptions = TaskRunOptions.Default;
+            runner.RunOptions = options;
             runner.hideFlags = HideFlags.HideInInspector;
 
             return runner;

--- a/src/TaskRunOptions.cs
+++ b/src/TaskRunOptions.cs
@@ -23,5 +23,10 @@ namespace UnityEngine
         /// Tasks are still NOT updated when the gameobject is disabled.
         /// </remarks>
         UpdateWhileComponentDisabled = 1 << 0,
+
+        /// <summary>
+        /// Enable diagnostic logging.
+        /// </summary>
+        DiagnosticLogging = 1 << 1,
     }
 }


### PR DESCRIPTION
To aid in debugging there is now a `TaskRunOptions.DiagnosticLogging` flag you can give when starting a task. (Alternatively you can enable it for all tasks with `ComponentTask.Config.GlobalDiagnosticsActive`).

Enabling the diagnostic logging will print output like this:
<img width="431" alt="Screenshot 2019-07-26 at 22 11 19" src="https://user-images.githubusercontent.com/14230060/61975700-846a0d80-aff2-11e9-8e90-218c6b4bb675.png">
(The 'GotValue' is for demo purposes only and not part of the diag logging)