### PR TITLE
Starting task on disabled component guards

### DIFF
--- a/src/ComponentTask/Exceptions/InactiveComponentException.cs
+++ b/src/ComponentTask/Exceptions/InactiveComponentException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ComponentTask.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when attempting to execute a operation on a inactive component.
+    /// </summary>
+    public sealed class InactiveComponentException : InvalidOperationException
+    {
+        internal InactiveComponentException(string message)
+            : base($"Invalid operation: {message}")
+        {
+        }
+    }
+}

--- a/src/ComponentTask/Exceptions/InactiveComponentException.cs.meta
+++ b/src/ComponentTask/Exceptions/InactiveComponentException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d8e135c34cb04394be3cdfe2d144015
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Exceptions/InactiveGameObjectException.cs
+++ b/src/ComponentTask/Exceptions/InactiveGameObjectException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ComponentTask.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when attempting to execute a operation on a inactive gameobject.
+    /// </summary>
+    public sealed class InactiveGameObjectException : InvalidOperationException
+    {
+        internal InactiveGameObjectException(string message)
+            : base($"Invalid operation: {message}")
+        {
+        }
+    }
+}

--- a/src/ComponentTask/Exceptions/InactiveGameObjectException.cs.meta
+++ b/src/ComponentTask/Exceptions/InactiveGameObjectException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ead01f92be044e56ac53eee740c01fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ComponentTask/Exceptions/TaskCreatorReturnedNullException.cs
+++ b/src/ComponentTask/Exceptions/TaskCreatorReturnedNullException.cs
@@ -8,7 +8,7 @@ namespace ComponentTask.Exceptions
     public sealed class TaskCreatorReturnedNullException : InvalidOperationException
     {
         internal TaskCreatorReturnedNullException()
-            : base($"Invalid operation: Null was returned from a task-creator function")
+            : base($"Invalid operation: Null was returned from a task-creator function.")
         {
         }
     }

--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -26,50 +26,73 @@ namespace ComponentTask.Internal
 
         public Task StartTask(Func<Task> taskCreator)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, logger);
         }
 
         public Task StartTask(Func<CancellationToken, Task> taskCreator)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, logger);
         }
 
         public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, data, logger);
         }
 
         public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, data, logger);
         }
 
         public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, logger);
         }
 
         public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, logger);
         }
 
         public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, data, logger);
         }
 
         public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data)
         {
+            this.ThrowForInvalidState();
+
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
             return this.taskRunner.StartTask(taskCreator, data, logger);
+        }
+
+        private void ThrowForInvalidState()
+        {
+            // Verify that this runner has not been destroyed.
+            if (!this)
+                throw new UnityEngine.MissingReferenceException("Task runner has been destroyed but you are still trying to access it.");
         }
 
         // Dynamically called from the Unity runtime.

--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using ComponentTask.Exceptions;
 using UnityEngine;
 
 namespace ComponentTask.Internal
@@ -93,6 +94,10 @@ namespace ComponentTask.Internal
             // Verify that this runner has not been destroyed.
             if (!this)
                 throw new UnityEngine.MissingReferenceException("Task runner has been destroyed but you are still trying to access it.");
+
+            // Verify that our gameobject is active.
+            if (!this.gameObject.activeInHierarchy)
+                throw new InactiveGameObjectException("Unable to start a task: GameObject is inactive.");
         }
 
         // Dynamically called from the Unity runtime.

--- a/src/ComponentTask/Internal/UnityHelper.cs
+++ b/src/ComponentTask/Internal/UnityHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using ComponentTask.Exceptions;
 
@@ -32,17 +33,23 @@ namespace ComponentTask.Internal
 
         public static void ThrowForInvalidObjectParam(UnityEngine.Object reference, string paramName)
         {
-            /* This follows the unity standard where 'null' throws a null-ref and the unity-side 
-            being destroyed throws a 'UnityEngine.MissingReferenceException'. 
-            
-            Unity has another behaviour when you define an inspector param but don't assign 
+            /* This follows the unity standard where 'null' throws a null-ref and the unity-side
+            being destroyed throws a 'UnityEngine.MissingReferenceException'.
+
+            Unity has another behaviour when you define an inspector param but don't assign
             it and then access it: that throws a 'UnityEngine.UnassignedReferenceException', but
             i don't know how to implement that without access to the serialization internals. */
 
             if (reference is null)
                 throw new ArgumentNullException(paramName);
             if (!reference)
-                throw new UnityEngine.MissingReferenceException($"The object of type '{reference.GetType().Name}' has been destroyed but you are still trying to access it.");
+                ThrowMissingReference(reference);
+        }
+
+        public static void ThrowMissingReference(UnityEngine.Object reference)
+        {
+            Debug.Assert(!object.ReferenceEquals(reference, null), "Reference is null");
+            throw new UnityEngine.MissingReferenceException($"The object of type '{reference.GetType().Name}' has been destroyed but you are still trying to access it.");
         }
 
         public static void LogException(Exception exception, UnityEngine.Object context)

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -445,5 +445,47 @@ namespace ComponentTask.Tests.PlayMode
             yield return null;
             Object.Destroy(go);
         }
+
+        [UnityTest]
+        public IEnumerator StartingTaskOnDisabledComponentThrows()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+
+            // Disable the component.
+            comp.enabled = false;
+
+            Assert.Throws<InactiveComponentException>(() => ComponentExtensions.StartTask(comp, () => Task.CompletedTask));
+
+            // Cleanup.
+            yield return null;
+            Object.Destroy(go);
+        }
+
+        [UnityTest]
+        public IEnumerator TaskCanBeStartedOnDisabledComponentWithUpdateWhileDisabled()
+        {
+            var count = 0;
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+
+            // Disable the component.
+            comp.enabled = false;
+
+            // Start task.
+            comp.StartTask(RunAsync, TaskRunOptions.UpdateWhileComponentDisabled);
+
+            yield return null;
+            Assert.AreEqual(1, count);
+
+            // Cleanup.
+            Object.Destroy(go);
+
+            async Task RunAsync()
+            {
+                await Task.Yield();
+                count++;
+            }
+        }
     }
 }

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -397,7 +397,7 @@ namespace ComponentTask.Tests.PlayMode
         }
 
         [UnityTest]
-        public IEnumerator DestroyedComponentThrowsMissingReferenceException()
+        public IEnumerator CreatingRunnerOnDestroyedComponentThrows()
         {
             var go = new GameObject("TestGameObject");
             var comp = go.AddComponent<MockComponent>();
@@ -406,7 +406,27 @@ namespace ComponentTask.Tests.PlayMode
             Assert.Throws<MissingReferenceException>(() => ComponentExtensions.GetTaskRunner(comp));
             Assert.Throws<MissingReferenceException>(() => ComponentExtensions.StartTask(comp, () => Task.CompletedTask));
 
+            // Cleanup.
             yield return null;
+            Object.Destroy(go);
+        }
+
+        [UnityTest]
+        public IEnumerator StartingTaskOnDestroyedRunnerThrows()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+            var runner = comp.GetTaskRunner();
+
+            // Destroy the component.
+            Object.DestroyImmediate(comp);
+
+            // Give the runner one frame to respond.
+            yield return null;
+
+            Assert.Throws<MissingReferenceException>(() => runner.StartTask(() => Task.CompletedTask));
+
+            // Cleanup.
             Object.Destroy(go);
         }
     }

--- a/tests/playmode/ComponentExtensionsTests.cs
+++ b/tests/playmode/ComponentExtensionsTests.cs
@@ -429,5 +429,21 @@ namespace ComponentTask.Tests.PlayMode
             // Cleanup.
             Object.Destroy(go);
         }
+
+        [UnityTest]
+        public IEnumerator StartingTaskOnDisabledGameObjectThrows()
+        {
+            var go = new GameObject("TestGameObject");
+            var comp = go.AddComponent<MockComponent>();
+
+            // Disable the gameobject.
+            go.SetActive(false);
+
+            Assert.Throws<InactiveGameObjectException>(() => ComponentExtensions.StartTask(comp, () => Task.CompletedTask));
+
+            // Cleanup.
+            yield return null;
+            Object.Destroy(go);
+        }
     }
 }


### PR DESCRIPTION
`StartTask(...)` now throws when called if the gameobject or component is disabled, reason is that it often leads to bugs as you might not realise that those tasks are not updated. Also this follows the behaviour of Unity coroutines. 

Adds two new exceptions:
* `InactiveComponentException`
* `InactiveGameObjectException`