### PR TITLE
Fix missing 'paused' diag log when disabling in Synchronous part of task

### DIFF
--- a/src/ComponentExtensions.cs
+++ b/src/ComponentExtensions.cs
@@ -486,7 +486,7 @@ namespace UnityEngine
             foreach (var runner in monoBehaviourRunners)
             {
                 // If there is a runner for that component then return that.
-                if (runner.RunOptions == options && runner.ComponentToFollow == component)
+                if (runner.RunOptions == options && object.ReferenceEquals(runner.ComponentToFollow, component))
                     return runner;
             }
 

--- a/src/ComponentTask/Internal/ContextScope.cs
+++ b/src/ComponentTask/Internal/ContextScope.cs
@@ -18,7 +18,7 @@ namespace ComponentTask.Internal
         public void Dispose()
         {
             // Sanity check that the static build method was used instead of the default constructor.
-            if (this.currentContext == null)
+            if (this.currentContext is null)
                 return;
 
             /* Verify that the scope is still (or again) the context we are expecting. This could

--- a/src/ComponentTask/Internal/DelegateExtensions.cs
+++ b/src/ComponentTask/Internal/DelegateExtensions.cs
@@ -25,7 +25,7 @@ namespace ComponentTask.Internal
             }
             catch (MemberAccessException)
             {
-                if (@delegate.Target != null)
+                if (!(@delegate.Target is null))
                     return $"{@delegate.Target.GetType().Name}.<private>";
                 return "<private>";
             }

--- a/src/ComponentTask/Internal/DiagTaskTracer.cs
+++ b/src/ComponentTask/Internal/DiagTaskTracer.cs
@@ -11,7 +11,7 @@ namespace ComponentTask.Internal
         private DiagTaskTracer(IDiagnosticLogger logger, string identifier)
         {
             Debug.Assert(!string.IsNullOrEmpty(identifier), "Invalid identifier");
-            Debug.Assert(logger != null, "Logger is null");
+            Debug.Assert(!(logger is null), "Logger is null");
 
             this.identifier = identifier;
             this.logger = logger;

--- a/src/ComponentTask/Internal/ITaskHandle.cs
+++ b/src/ComponentTask/Internal/ITaskHandle.cs
@@ -1,7 +1,11 @@
+using System.Threading.Tasks;
+
 namespace ComponentTask.Internal
 {
     internal interface ITaskHandle
     {
+        Task Task { get; }
+
         bool IsCompleted { get; }
 
         DiagTaskTracer DiagTracer { get; }

--- a/src/ComponentTask/Internal/ManualSynchronizationContext.cs
+++ b/src/ComponentTask/Internal/ManualSynchronizationContext.cs
@@ -40,7 +40,7 @@ namespace ComponentTask.Internal
             never end. */
 
             // Get a temporary list to gather items in (ThreadStatic so safe).
-            if (executeList == null)
+            if (executeList is null)
                 executeList = new List<(SendOrPostCallback, object)>();
             else
                 executeList.Clear();

--- a/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
+++ b/src/ComponentTask/Internal/MonoBehaviourTaskRunner.cs
@@ -33,7 +33,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, logger);
+            var result = this.taskRunner.StartTask(taskCreator, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task StartTask(Func<CancellationToken, Task> taskCreator)
@@ -41,7 +44,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, logger);
+            var result = this.taskRunner.StartTask(taskCreator, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task StartTask<TIn>(Func<TIn, Task> taskCreator, TIn data)
@@ -49,7 +55,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, data, logger);
+            var result = this.taskRunner.StartTask(taskCreator, data, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task StartTask<TIn>(Func<TIn, CancellationToken, Task> taskCreator, TIn data)
@@ -57,7 +66,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, data, logger);
+            var result = this.taskRunner.StartTask(taskCreator, data, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task<TOut> StartTask<TOut>(Func<Task<TOut>> taskCreator)
@@ -65,7 +77,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, logger);
+            var result = this.taskRunner.StartTask(taskCreator, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task<TOut> StartTask<TOut>(Func<CancellationToken, Task<TOut>> taskCreator)
@@ -73,7 +88,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, logger);
+            var result = this.taskRunner.StartTask(taskCreator, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task<TOut> StartTask<TIn, TOut>(Func<TIn, Task<TOut>> taskCreator, TIn data)
@@ -81,7 +99,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, data, logger);
+            var result = this.taskRunner.StartTask(taskCreator, data, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         public Task<TOut> StartTask<TIn, TOut>(Func<TIn, CancellationToken, Task<TOut>> taskCreator, TIn data)
@@ -89,7 +110,10 @@ namespace ComponentTask.Internal
             this.ThrowForInvalidState();
 
             var logger = this.DiagnosticLogging ? this as IDiagnosticLogger : null;
-            return this.taskRunner.StartTask(taskCreator, data, logger);
+            var result = this.taskRunner.StartTask(taskCreator, data, logger);
+            if (this.isPaused)
+                this.LogPause(result);
+            return result;
         }
 
         private void ThrowForInvalidState()
@@ -184,6 +208,18 @@ namespace ComponentTask.Internal
         {
             if (this.DiagnosticLogging)
                 this.taskRunner.ForAllRunningTasks(t => t.DiagTracer.LogPaused());
+        }
+
+        private void LogPause(Task task)
+        {
+            if (this.DiagnosticLogging)
+                this.taskRunner.ForAllRunningTasks(PauseSpecificTask);
+
+            void PauseSpecificTask(ITaskHandle th)
+            {
+                if (object.ReferenceEquals(th.Task, task))
+                    th.DiagTracer.LogPaused();
+            }
         }
 
         private void LogResume()

--- a/src/ComponentTask/Internal/SynchronizationContextExtensions.cs
+++ b/src/ComponentTask/Internal/SynchronizationContextExtensions.cs
@@ -10,7 +10,7 @@ namespace ComponentTask.Internal
             if (context is null)
                 throw new ArgumentNullException(nameof(context));
 
-            return SynchronizationContext.Current == context;
+            return object.ReferenceEquals(SynchronizationContext.Current, context);
         }
     }
 }

--- a/src/ComponentTask/Internal/TaskHandle.cs
+++ b/src/ComponentTask/Internal/TaskHandle.cs
@@ -48,7 +48,7 @@ namespace ComponentTask.Internal
 
         public TaskHandle(IExceptionHandler exceptionHandler, DiagTaskTracer diagTracer)
         {
-            Debug.Assert(exceptionHandler != null, "No exception handler provided");
+            Debug.Assert(!(exceptionHandler is null), "No exception handler provided");
 
             this.completeSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.exceptionHandler = exceptionHandler;
@@ -116,7 +116,7 @@ namespace ComponentTask.Internal
 
         public TaskHandle(IExceptionHandler exceptionHandler, DiagTaskTracer diagTracer)
         {
-            Debug.Assert(exceptionHandler != null, "No exception handler provided");
+            Debug.Assert(!(exceptionHandler is null), "No exception handler provided");
 
             this.completeSource = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
             this.exceptionHandler = exceptionHandler;

--- a/src/ComponentTask/Internal/TaskHandle.cs
+++ b/src/ComponentTask/Internal/TaskHandle.cs
@@ -123,7 +123,9 @@ namespace ComponentTask.Internal
             this.diagTracer = diagTracer;
         }
 
-        public Task<T> Task => this.completeSource.Task;
+        public Task Task => this.completeSource.Task;
+
+        public Task<T> TaskWithReturn => this.completeSource.Task;
 
         public DiagTaskTracer DiagTracer => this.diagTracer;
 

--- a/src/ComponentTask/Internal/UnityHelper.cs
+++ b/src/ComponentTask/Internal/UnityHelper.cs
@@ -48,7 +48,7 @@ namespace ComponentTask.Internal
 
         public static void ThrowMissingReference(UnityEngine.Object reference)
         {
-            Debug.Assert(!object.ReferenceEquals(reference, null), "Reference is null");
+            Debug.Assert(!(reference is null), "Reference is null");
             throw new UnityEngine.MissingReferenceException($"The object of type '{reference.GetType().Name}' has been destroyed but you are still trying to access it.");
         }
 

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -64,7 +64,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked();
                 return this.WrapTask(taskCreator.Invoke(), diagTracer);
             }
@@ -88,7 +88,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked();
                 return this.WrapTask(taskCreator.Invoke(this.cancelSource.Token), diagTracer);
             }
@@ -113,7 +113,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked(data);
                 return this.WrapTask(taskCreator.Invoke(data), diagTracer);
             }
@@ -138,7 +138,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked(data);
                 return this.WrapTask(taskCreator.Invoke(data, this.cancelSource.Token), diagTracer);
             }
@@ -162,7 +162,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked();
                 return this.WrapTask<TOut>(taskCreator.Invoke(), diagTracer);
             }
@@ -186,7 +186,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked();
                 return this.WrapTask<TOut>(taskCreator.Invoke(this.cancelSource.Token), diagTracer);
             }
@@ -211,7 +211,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked(data);
                 return this.WrapTask<TOut>(taskCreator.Invoke(data), diagTracer);
             }
@@ -236,7 +236,7 @@ namespace ComponentTask
             // Activate our context and wrap the task.
             using (var contextScope = ContextScope.WithContext(this.context))
             {
-                var diagTracer = logger == null ? null : DiagTaskTracer.Create(logger, taskCreator);
+                var diagTracer = logger is null ? null : DiagTaskTracer.Create(logger, taskCreator);
                 diagTracer?.LogInvoked(data);
                 return this.WrapTask<TOut>(taskCreator.Invoke(data, this.cancelSource.Token), diagTracer);
             }
@@ -379,7 +379,7 @@ namespace ComponentTask
 
         private void RegisterTaskHandle(ITaskHandle handle)
         {
-            Debug.Assert(handle != null, "Null task-handle provided");
+            Debug.Assert(!(handle is null), "Null task-handle provided");
             lock (this.runningTasksLock)
             {
                 this.runningTasks.Add(handle);

--- a/src/ComponentTask/LocalTaskRunner.cs
+++ b/src/ComponentTask/LocalTaskRunner.cs
@@ -374,7 +374,7 @@ namespace ComponentTask
             task.ContinueWith(TaskHandle<T>.UpdateFromTask, handle, TaskContinuationOptions.ExecuteSynchronously);
 
             this.RegisterTaskHandle(handle);
-            return handle.Task;
+            return handle.TaskWithReturn;
         }
 
         private void RegisterTaskHandle(ITaskHandle handle)


### PR DESCRIPTION
If the gameObject was disabled in the synchronous part of a task then no 'paused' diag was logged, this fixes that.

For example, the following did not produce a 'paused' diag log:
```c#
void Start()
{
    this.StartTask(RunAsync);
}

async Task RunAsync()
{
    this.gameObject.SetActive(false);
    await Task.Yield();
}
```