### PR TITLE
Unpack aggregate exceptions in DiagTaskTracer

### DIFF
--- a/src/ComponentTask/Internal/DiagTaskTracer.cs
+++ b/src/ComponentTask/Internal/DiagTaskTracer.cs
@@ -76,7 +76,7 @@ namespace ComponentTask.Internal
                 for (int i = 0; i < exceptions.Count; i++)
                 {
                     if (i != 0)
-                        msgBuilder.Append("\n");
+                        msgBuilder.Append(", ");
                     msgBuilder.Append(exceptions[i].Message);
                 }
 


### PR DESCRIPTION
Unpack `System.AggregateException` in the diagnostic logging to avoid the useless 'One or more errors occurred' log.