### PR TITLE
Add info about link.xml for mono builds

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -88,6 +88,20 @@ commit.</p>
 <h3 id="upgrading">Upgrading</h3>
 <p>To update to a newer version simply open your package manifest (<code>Packages/manifest.json</code>) and set
 the tag at the end of the git url (for example <code>v1.8.1</code>) to a later version.</p>
+<h3 id="mono">Link.xml file for Mono builds</h3>
+<p>If you use the Mono scripting backend, you may get error messages in builds stating that constructors for <code>System.Diagnostics.SystemDiagnosticsSection</code> or <code>System.Diagnostics.FilterElement</code> does not exist. You can fix this by including a file named <code>link.xml</code> in the <code>Assets</code> folder (or subfolder) with the following ocntents:</p>
+<pre><code>
+  &lt;linker&gt;
+    &lt;assembly fullname="System, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"&gt;
+        &lt;type fullname="System.Diagnostics.SystemDiagnosticsSection" preserve="fields"&gt;
+          &lt;method signature="System.Void .ctor()"/&gt;
+        &lt;/type&gt;
+        &lt;type fullname="System.Diagnostics.FilterElement" preserve="fields"&gt;
+          &lt;method signature="System.Void .ctor()"/&gt;
+        &lt;/type&gt;
+      &lt;/assembly&gt;
+  &lt;/linker&gt;
+  </code></pre>
 </article>
           </div>
           


### PR DESCRIPTION
Workaround for https://github.com/BastianBlokland/componenttask-unity/issues/20

I tried adding this `link.xml` file to the `src` folder (with a `.meta` file), but it does not get picked up by the Unity build when it is not directly under the `Assets` folder it seems.

Another solution would be to create a post build triggered script that automatically adds a link.xml file to the projects Asset folder, but I feel that such a solution would be too intrusive on other developers, and may confuse them.

I have tested a `link.xml` file as described here, and it "works on my machine" (tm). :-) So it would be nice with a confirmation from another build somewhere else.